### PR TITLE
Fix: alert message for Twitter and Facebook btn

### DIFF
--- a/src/components/pages/SignInPage/index.tsx
+++ b/src/components/pages/SignInPage/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import MyPageTemplate from '../../templates/SignInTemplate'
 
 const SignInPage: React.FC<{}> = () => (
-  <MyPageTemplate onClick={() => alert('Now just google authentication is available...')} />
+  <MyPageTemplate onClick={() => alert('For now, Google Auth is only available...')} />
 )
 
 export default SignInPage


### PR DESCRIPTION
## 概要
Twitter Auth & Facebook Authボタンを押した際に出るalert messageを変更
