### PR TITLE
Set current user

### DIFF
--- a/src/components/molecules/Forms/DirectoryForm/index.tsx
+++ b/src/components/molecules/Forms/DirectoryForm/index.tsx
@@ -5,8 +5,9 @@ import Typography from '@material-ui/core/Typography'
 import { createDirectory } from '../../../../actions/directories'
 
 interface Props {
+  currentUser: firebase.User
   onSubmit: () => void
-  createDirectory: (values: Values) => Promise<void>
+  createDirectory: (values: Values, currentUserUid: string) => Promise<void>
 }
 
 export interface Values {
@@ -27,14 +28,14 @@ const validate = (values: Values) => {
   return errors
 }
 
-const DirectoryForm: React.FC<Props> = ({ onSubmit, createDirectory }) => (
+const DirectoryForm: React.FC<Props> = ({ currentUser, onSubmit, createDirectory }) => (
   <Fragment>
     <Typography variant="h6">New Directory</Typography>
     <Formik
       initialValues={{ directoryName: '' }}
       validate={validate}
       onSubmit={(values: Values, { setSubmitting }: FormikActions<Values>) => {
-        createDirectory(values).then(() => {
+        createDirectory(values, currentUser.uid).then(() => {
           onSubmit()
           setSubmitting(false)
         })

--- a/src/components/pages/MyPage/index.tsx
+++ b/src/components/pages/MyPage/index.tsx
@@ -3,17 +3,24 @@ import { connect } from 'react-redux'
 import { fetchDirectories } from '../../../actions/directories'
 import { ReduxAPIStruct } from '../../../reducers/static-types'
 import { FirebaseSnapShot } from '../../../utils/firebase'
+import CircularProgress from '@material-ui/core/CircularProgress'
 import MyPageTemplate from '../../templates/MyPageTemplate'
 
 interface Props {
-  fetchDirectories: () => void
+  currentUser: firebase.User | null
+  fetchDirectories: (currentUserUid: string | null) => void
   directories: ReduxAPIStruct<FirebaseSnapShot[]>
 }
 
-const MyPage: React.FC<Props> = ({ fetchDirectories, directories }) => {
-  useEffect(() => fetchDirectories(), [])
+const MyPage: React.FC<Props> = ({ currentUser, fetchDirectories, directories }) => {
+  useEffect(() => {
+    const currentUserUid = currentUser ? currentUser.uid : null
+    fetchDirectories(currentUserUid)
+  }, [currentUser])
 
-  return <MyPageTemplate directories={directories} />
+  if (!currentUser) return <CircularProgress />
+
+  return <MyPageTemplate directories={directories} currentUser={currentUser} />
 }
 
 export default connect(

--- a/src/components/templates/MyPageTemplate/index.tsx
+++ b/src/components/templates/MyPageTemplate/index.tsx
@@ -10,6 +10,7 @@ import { ReduxAPIStruct } from '../../../reducers/static-types'
 import * as styles from './style.css'
 
 interface Props {
+  currentUser: firebase.User
   directories: ReduxAPIStruct<FirebaseSnapShot[]>
 }
 
@@ -17,7 +18,7 @@ const onClickSignOut = () => {
   auth.signOut()
 }
 
-const MyPageTemplate: React.FC<Props> = ({ directories }) => {
+const MyPageTemplate: React.FC<Props> = ({ currentUser, directories }) => {
   const [isModalOpen, setISModalOpen] = useState(false)
 
   return (
@@ -36,7 +37,7 @@ const MyPageTemplate: React.FC<Props> = ({ directories }) => {
           onClose={() => setISModalOpen(false)}
         >
           <div className={styles.modal}>
-            <DirectoryForm onSubmit={() => setISModalOpen(false)} />
+            <DirectoryForm currentUser={currentUser} onSubmit={() => setISModalOpen(false)} />
           </div>
         </Modal>
       </div>

--- a/src/components/utils/private-route.tsx
+++ b/src/components/utils/private-route.tsx
@@ -6,14 +6,23 @@ interface Props {
   exact: boolean
   path: string
   component: ConnectedComponentClass<React.FC<any>, any>
+  currentUser: firebase.User | null
   isAuthorized: boolean
 }
 
-const PrivateRoute: React.FC<Props> = ({ exact, path, component: Component, isAuthorized }) => (
+const PrivateRoute: React.FC<Props> = ({
+  exact,
+  path,
+  component: Component,
+  currentUser,
+  isAuthorized,
+}) => (
   <Route
     exact={exact}
     path={path}
-    render={() => (isAuthorized ? <Component /> : <Redirect to="/sign_in" />)}
+    render={() =>
+      isAuthorized ? <Component currentUser={currentUser} /> : <Redirect to="/sign_in" />
+    }
   />
 )
 

--- a/src/components/utils/router.tsx
+++ b/src/components/utils/router.tsx
@@ -10,12 +10,15 @@ import EditorPage from '../pages/EditorPage'
 
 const Router: React.FC<{}> = () => {
   const [authState, setAuthState] = useState({ isLoading: true, isAuthorized: false })
+  const [currentUser, setCurrentUser] = useState<firebase.User | null>(null)
   useEffect(() => {
     auth.onAuthStateChanged(user => {
       if (user) {
         setAuthState({ isLoading: false, isAuthorized: true })
+        setCurrentUser(user)
       } else {
         setAuthState({ isLoading: false, isAuthorized: false })
+        setCurrentUser(null)
       }
     })
   }, [auth])
@@ -28,7 +31,13 @@ const Router: React.FC<{}> = () => {
     <BrowserRouter>
       <Switch>
         <PublicRoute exact path="/sign_in" component={SignInPage} isAuthorized={isAuthorized} />
-        <PrivateRoute exact path="/:username" component={MyPage} isAuthorized={isAuthorized} />
+        <PrivateRoute
+          exact
+          path="/mypage"
+          component={MyPage}
+          currentUser={currentUser}
+          isAuthorized={isAuthorized}
+        />
         <Route exact path="/" component={isAuthorized ? MyPage : SignInPage} />
         {/* TODO: It's tmp route, need to make it Private Route & Use uid  */}
         <Route exact path="/:id/edit" component={EditorPage} />


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
- currentUserを使えるように
- directoriesをsubcollection化し、currentUserに紐づいたdirectoriesのみ閲覧、作成できるように
## 詳細
currentUserはrouter.tsxでsetしその後子コンポーネントにpropsとして流し込んでいく形にしています
## 特にレビューしてほしいところ

## 関連Issue

## TodoList

## その他
