### PR TITLE
Create master branch automatically

### DIFF
--- a/src/actions/directories.ts
+++ b/src/actions/directories.ts
@@ -86,6 +86,7 @@ export const createDirectory = (values: Values, currentUserUid: string) => {
         updatedAt: Date.now(),
       })
       .then(newDoc => {
+        // newDirectoryをstoreへ保存
         newDoc
           .get()
           .then(snapShot => {
@@ -96,6 +97,17 @@ export const createDirectory = (values: Values, currentUserUid: string) => {
           })
           .catch(error => {
             dispatch(directoryFirebaseFailure({ statusCode: 500, message: error }))
+          })
+        // newDirectory配下にmaster branchを追加
+        newDoc
+          .collection('branches')
+          .add({
+            name: 'master',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          })
+          .catch(error => {
+            dispatch(directoryFirebaseFailure({ statusCode: 500, message: error.message }))
           })
       })
       .catch(error => {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
ディレクトリ作成時にmasterブランチは自動生成、master branchは削除できないようにセキュリティルールを追加
```
        match /branches/{branchName} {
          allow read, create, update: if true;
          allow delete: if branchName != 'master';
        }
```
## 詳細

## 特にレビューしてほしいところ

## 関連Issue

## TodoList

## その他
