### PR TITLE
文字が選択されたときもtoolbarを表示

### DIFF
--- a/src/components/organisms/MarkdownEditor/index.tsx
+++ b/src/components/organisms/MarkdownEditor/index.tsx
@@ -37,10 +37,24 @@ const MarkdownEditor: React.FC<{}> = () => {
     return lastInputValue
   }
 
+  const getSelectedText = () => {
+    if (!editorState) return
+    const selectionState = editorState.getSelection()
+    const anchorKey = selectionState.getAnchorKey()
+    const currentContent = editorState.getCurrentContent()
+    const currentContentBlock = currentContent.getBlockForKey(anchorKey)
+    const start = selectionState.getStartOffset()
+    const end = selectionState.getEndOffset()
+    const selectedText = currentContentBlock.getText().slice(start, end)
+
+    return selectedText
+  }
+
   useEffect(() => {
     const inputValue = getInputValue()
+    const selectedText = getSelectedText()
 
-    if (inputValue === '') {
+    if (inputValue === '' || selectedText !== '') {
       setShouldShowStyleButtons(true)
     } else {
       setShouldShowStyleButtons(false)


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
表題通りです。
![image](https://user-images.githubusercontent.com/40731267/57059236-4b6e1580-6cef-11e9-9c5c-a86c8f2d8e8a.png)

## その他
こんな使い所多そうなfunctionは用意しておいて欲しいという気持ち。
https://draftjs.org/docs/api-reference-selection-state

