### PR TITLE
Refactor directories action

### DIFF
--- a/src/actions/static-types.ts
+++ b/src/actions/static-types.ts
@@ -1,4 +1,15 @@
+import { ReduxAPIError } from '../reducers/static-types'
+
 export interface BaseAction {
   type: string
   payload?: any
+}
+
+export interface FirebaseAPIRequest extends BaseAction {
+  type: string
+}
+
+export interface FirebaseAPIFailure extends BaseAction {
+  type: string
+  payload: { error: ReduxAPIError }
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
actions/directories.tsのリファクタ
## 詳細
FirebaseAPIRequest, FirebaseAPIFailureはおそらく他のアクションでも使うので、共通化するためにactions/static-types.tsに定義し直しました
## 特にレビューしてほしいところ

## 関連Issue

## TodoList

## その他
