### PR TITLE
Limit access to directory page

### DIFF
--- a/src/actions/directories.ts
+++ b/src/actions/directories.ts
@@ -25,9 +25,9 @@ interface AddDirectoryAction extends BaseAction {
 
 export type DirectoriesAction =
   | FirebaseAPIRequest
+  | FirebaseAPIFailure
   | SetDirectoriesAction
   | AddDirectoryAction
-  | FirebaseAPIFailure
 
 // NOTE: Firebaseはクライアント側のネットワーク不良などでデータのfetchに失敗してもerrorを吐かず、
 //       空配列を返してくる... :anger_jenkins:
@@ -87,6 +87,44 @@ export const createDirectory = (values: Values, currentUserUid: string) => {
             updatedAt: Date.now(),
           })
           .catch(error => dispatch(directoryFirebaseFailure(error.message)))
+      })
+      .catch(error => dispatch(directoryFirebaseFailure(error.message)))
+  }
+}
+
+//-------------------------------------------------------------------------
+// IsInvalidDirectory
+// ------------------------------------------------------------------------
+interface CheckDirectoryIdAction extends BaseAction {
+  type: string
+  payload: { isValidDirectoryId: ReduxAPIStruct<boolean> }
+}
+
+export type IsInvalidDirectoryAction =
+  | FirebaseAPIRequest
+  | FirebaseAPIFailure
+  | CheckDirectoryIdAction
+
+export const checkDirectoryId = (currentUserUid: string, directoryId: string) => {
+  return (dispatch: ThunkDispatch<{}, {}, IsInvalidDirectoryAction>) => {
+    dispatch({ type: actionTypes.DIRECTORY_FIREBASE_REQUEST })
+    db.collection('users')
+      .doc(currentUserUid)
+      .collection('directories')
+      .doc(directoryId)
+      .get()
+      .then(doc => {
+        if (doc.exists) {
+          dispatch({
+            type: actionTypes.DIRECTORY_CHECK_ID,
+            payload: { isValidDirectoryId: true },
+          })
+        } else {
+          dispatch({
+            type: actionTypes.DIRECTORY_CHECK_ID,
+            payload: { isValidDirectoryId: false },
+          })
+        }
       })
       .catch(error => dispatch(directoryFirebaseFailure(error.message)))
   }

--- a/src/components/pages/DirectoryPage/index.tsx
+++ b/src/components/pages/DirectoryPage/index.tsx
@@ -1,18 +1,39 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { connect } from 'react-redux'
 import { RouteComponentProps } from 'react-router-dom'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import { checkDirectoryId } from '../../../actions/directories'
+import { ReduxAPIStruct } from '../../../reducers/static-types'
 
 interface MatchParams {
   directoryId: string
 }
 
 interface Props extends RouteComponentProps<MatchParams> {
-  currentUser: firebase.User
+  currentUser: firebase.User | null
+  isValidDirectory: ReduxAPIStruct<boolean>
+  checkDirectoryId: (currentUserUid: string, directoryId: string) => void
 }
 
-const DirectoryPage: React.FC<Props> = ({ match }) => {
+const DirectoryPage: React.FC<Props> = ({
+  match,
+  currentUser,
+  isValidDirectory,
+  checkDirectoryId,
+}) => {
+  if (!currentUser) return <CircularProgress />
+
   const {
     params: { directoryId },
   } = match
+
+  useEffect(() => checkDirectoryId(currentUser.uid, directoryId), [])
+
+  if (isValidDirectory.status === 'default' || isValidDirectory.status === 'fetching') {
+    return <CircularProgress />
+  }
+
+  if (!isValidDirectory.data) return <h2>404 Not Found</h2>
 
   return (
     <h3>
@@ -23,4 +44,9 @@ const DirectoryPage: React.FC<Props> = ({ match }) => {
   )
 }
 
-export default DirectoryPage
+export default connect(
+  ({ isValidDirectory }: Record<string, ReduxAPIStruct<boolean>>) => ({
+    isValidDirectory,
+  }),
+  { checkDirectoryId }
+)(DirectoryPage)

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,6 +6,7 @@ export const actionTypes = keyMirror({
   DIRECTORY_FIREBASE_REQUEST_FAILURE: null,
   DIRECTORY_SET: null,
   DIRECTORY_ADD: null,
+  DIRECTORY_CHECK_ID: null,
 
   // Modal
   MODAL_AUTHENTICATION_OPEN: null,

--- a/src/reducers/directories.ts
+++ b/src/reducers/directories.ts
@@ -1,6 +1,6 @@
 import { actionTypes } from '../constants'
 import { ReduxAPIStruct, defaultSet } from './static-types'
-import { DirectoriesAction } from '../actions/directories'
+import { DirectoriesAction, IsInvalidDirectoryAction } from '../actions/directories'
 import { FirebaseSnapShot } from '../utils/firebase'
 
 export const directories = (
@@ -10,6 +10,9 @@ export const directories = (
   switch (action.type) {
     case actionTypes.DIRECTORY_FIREBASE_REQUEST:
       return { ...state, status: 'fetching' }
+
+    case actionTypes.DIRECTORY_FIREBASE_REQUEST_FAILURE:
+      return { ...state, status: 'failure', error: action.payload.message }
 
     case actionTypes.DIRECTORY_SET:
       if ('directories' in action.payload) {
@@ -23,9 +26,23 @@ export const directories = (
         return { ...state, status: 'success', data: state.data.concat(action.payload.newDir) }
       }
       return state
+  }
+  return state
+}
+
+export const isValidDirectory = (
+  state: ReduxAPIStruct<boolean> = defaultSet(),
+  action: IsInvalidDirectoryAction
+): ReduxAPIStruct<boolean> => {
+  switch (action.type) {
+    case actionTypes.DIRECTORY_FIREBASE_REQUEST:
+      return { ...state, status: 'fetching' }
 
     case actionTypes.DIRECTORY_FIREBASE_REQUEST_FAILURE:
-      return { ...state, status: 'failure', error: action.payload.error }
+      return { ...state, status: 'failure', error: action.payload.message }
+
+    case actionTypes.DIRECTORY_CHECK_ID:
+      return { ...state, status: 'success', data: action.payload.isValidDirectoryId }
   }
   return state
 }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,9 +1,10 @@
 import { combineReducers } from 'redux'
-import { directories } from './directories'
+import { directories, isValidDirectory } from './directories'
 import { authenticationModals } from './modals'
 
 const rootReducer = combineReducers({
   directories,
+  isValidDirectory,
   authenticationModals,
 })
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
DBに存在する有効なdirectoryIdでない場合、 `/:directoryId`にアクセスしても404 Not Foundを表示するように
## 詳細

## 特にレビューしてほしいところ

## 関連Issue

## TodoList

## その他
