### PR TITLE
Enable to create branch

### DIFF
--- a/src/actions/branches.ts
+++ b/src/actions/branches.ts
@@ -1,0 +1,47 @@
+import { db, FirebaseSnapShot } from '../utils/firebase'
+import { ThunkDispatch } from 'redux-thunk'
+import { actionTypes } from '../constants'
+import { ReduxAPIStruct } from '../reducers/static-types'
+import { BaseAction, FirebaseAPIRequest, FirebaseAPIFailure } from './static-types'
+import { Values } from '../components/molecules/Forms/BranchForm'
+
+const branchFirebaseFailure = (message: string) => ({
+  type: actionTypes.BRANCH__FIREBASE_REQUEST_FAILURE,
+  payload: { statusCode: 500, message },
+})
+
+// -------------------------------------------------------------------------
+// Branches
+// -------------------------------------------------------------------------
+interface CreateBranchAction extends BaseAction {
+  type: string
+  payload: { newBranch: ReduxAPIStruct<FirebaseSnapShot> }
+}
+
+export type BranchesAction = FirebaseAPIRequest | FirebaseAPIFailure | CreateBranchAction
+
+export const createBranch = (values: Values, currentUserUid: string, directoryId: string) => {
+  return async (dispatch: ThunkDispatch<{}, {}, BranchesAction>) => {
+    dispatch({ type: actionTypes.BRANCH__FIREBASE_REQUEST })
+    db.collection('users')
+      .doc(currentUserUid)
+      .collection('directories')
+      .doc(directoryId)
+      .collection('branches')
+      .add({
+        name: values.branchName,
+        state: 'open',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+      .then(newDocRef => {
+        newDocRef.get().then(snapShot => {
+          dispatch({
+            type: actionTypes.BRANCH__ADD,
+            payload: { newBranch: snapShot },
+          })
+        })
+      })
+      .catch(error => dispatch(branchFirebaseFailure(error.message)))
+  }
+}

--- a/src/components/molecules/Forms/BranchForm/index.tsx
+++ b/src/components/molecules/Forms/BranchForm/index.tsx
@@ -1,0 +1,59 @@
+import React, { Fragment } from 'react'
+import { connect } from 'react-redux'
+import { Formik, Field, Form, FormikActions, ErrorMessage } from 'formik'
+import Typography from '@material-ui/core/Typography'
+import { createBranch } from '../../../../actions/branches'
+
+interface Props {
+  directoryId: string
+  currentUser: firebase.User
+  createBranch: (values: Values, currentUserUid: string, directoryId: string) => Promise<void>
+}
+
+export interface Values {
+  branchName: string
+}
+
+interface ErrorMessages {
+  branchName?: string
+}
+
+const validate = (values: Values) => {
+  const errors: ErrorMessages = {}
+
+  if (!values.branchName) {
+    errors.branchName = 'Required'
+  }
+
+  return errors
+}
+
+const BranchForm: React.FC<Props> = ({ directoryId, currentUser, createBranch }) => (
+  <Fragment>
+    <Typography variant="h6">New Branch</Typography>
+    <Formik
+      initialValues={{ branchName: '' }}
+      validate={validate}
+      onSubmit={(values: Values, { setSubmitting }: FormikActions<Values>) => {
+        createBranch(values, currentUser.uid, directoryId).then(() => {
+          setSubmitting(false)
+        })
+      }}
+      render={() => (
+        <Form>
+          <label htmlFor="branchName">branch Name</label>
+          <Field id="branchName" name="branchName" placeholder="branch name" type="text" />
+          <ErrorMessage component="div" name="branchName" />
+          <button type="submit" style={{ display: 'block' }}>
+            Submit
+          </button>
+        </Form>
+      )}
+    />
+  </Fragment>
+)
+
+export default connect(
+  null,
+  { createBranch }
+)(BranchForm)

--- a/src/components/pages/DirectoryPage/index.tsx
+++ b/src/components/pages/DirectoryPage/index.tsx
@@ -5,6 +5,7 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import { checkDirectoryId } from '../../../actions/directories'
 import { ReduxAPIStruct } from '../../../reducers/static-types'
 import { FirebaseSnapShot } from '../../../utils/firebase'
+import BranchForm from '../../molecules/Forms/BranchForm'
 
 interface MatchParams {
   directoryId: string
@@ -56,6 +57,7 @@ const DirectoryPage: React.FC<Props & DispatchProps> = ({
           <li key={index}>{querySnapShot.data().name}</li>
         ))}
       </ol>
+      <BranchForm directoryId={directoryId} currentUser={currentUser} />
     </Fragment>
   )
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,6 +12,7 @@ export const actionTypes = keyMirror({
   BRANCH__FIREBASE_REQUEST: null,
   BRANCH__FIREBASE_REQUEST_FAILURE: null,
   BRANCH__SET: null,
+  BRANCH__ADD: null,
 
   // Modal
   MODAL__AUTHENTICATION_OPEN: null,

--- a/src/reducers/branches.ts
+++ b/src/reducers/branches.ts
@@ -1,10 +1,11 @@
 import { actionTypes } from '../constants'
 import { ReduxAPIStruct, defaultSet } from './static-types'
 import { FirebaseSnapShot } from '../utils/firebase'
+import { BranchesAction } from '../actions/branches'
 
 export const branches = (
   state: ReduxAPIStruct<FirebaseSnapShot[]> = defaultSet(),
-  action: any
+  action: BranchesAction
 ): ReduxAPIStruct<FirebaseSnapShot[]> => {
   switch (action.type) {
     case actionTypes.BRANCH__FIREBASE_REQUEST:
@@ -15,6 +16,12 @@ export const branches = (
 
     case actionTypes.BRANCH__SET:
       return { ...state, status: 'success', data: action.payload.branches }
+
+    case actionTypes.BRANCH__ADD:
+      if ('newBranch' in action.payload) {
+        if (state.data === null) return state
+        return { ...state, status: 'success', data: state.data.concat(action.payload.newBranch) }
+      }
   }
   return state
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
ブランチ作成を可能にしました。作成するとディレクトリページのブランチ一覧に即時反映されます
## 詳細
#89 とロジック的にはほぼ同じ
## その他
UIはマイページよりはるかに割り切りました。バックエンドのデータ管理に特化したPRです。