### PR TITLE
Arrange static types

### DIFF
--- a/src/actions/branches.ts
+++ b/src/actions/branches.ts
@@ -1,8 +1,8 @@
 import { db, FirebaseSnapShot } from '../utils/firebase'
 import { ThunkDispatch } from 'redux-thunk'
 import { actionTypes } from '../common/constants/action-types'
-import { ReduxAPIStruct } from '../reducers/static-types'
-import { BaseAction, FirebaseAPIRequest, FirebaseAPIFailure } from './static-types'
+import { ReduxAPIStruct } from '../common/static-types/api-struct'
+import { BaseAction, FirebaseAPIRequest, FirebaseAPIFailure } from '../common/static-types/actions'
 import { Values } from '../components/molecules/Forms/BranchForm'
 
 // -------------------------------------------------------------------------

--- a/src/actions/commits.ts
+++ b/src/actions/commits.ts
@@ -3,8 +3,8 @@ import { ThunkDispatch } from 'redux-thunk'
 import { RawDraftContentBlock } from 'draft-js'
 import { convertToText } from '../common/functions'
 import { actionTypes } from '../common/constants/action-types'
-import { BaseAction, FirebaseAPIRequest, FirebaseAPIFailure } from './static-types'
-import { ReduxAPIStruct } from '../reducers/static-types'
+import { BaseAction, FirebaseAPIRequest, FirebaseAPIFailure } from '../common/static-types/actions'
+import { ReduxAPIStruct } from '../common/static-types/api-struct'
 import { Values } from '../components/molecules/Forms/CommitForm'
 
 // -------------------------------------------------------------------------

--- a/src/actions/directories.ts
+++ b/src/actions/directories.ts
@@ -1,8 +1,8 @@
 import { db, FirebaseSnapShot } from '../utils/firebase'
 import { ThunkDispatch } from 'redux-thunk'
 import { actionTypes } from '../common/constants/action-types'
-import { ReduxAPIStruct } from '../reducers/static-types'
-import { BaseAction, FirebaseAPIRequest, FirebaseAPIFailure } from './static-types'
+import { ReduxAPIStruct } from '../common/static-types/api-struct'
+import { BaseAction, FirebaseAPIRequest, FirebaseAPIFailure } from '../common/static-types/actions'
 import { Values } from '../components/molecules/Forms/DirectoryForm'
 
 // -------------------------------------------------------------------------

--- a/src/actions/modals.ts
+++ b/src/actions/modals.ts
@@ -1,6 +1,6 @@
 import { ThunkDispatch } from 'redux-thunk'
 import { actionTypes } from '../common/constants/action-types'
-import { BaseAction } from './static-types'
+import { BaseAction } from '../common/static-types/actions'
 
 interface AuthenticationModalOpenAction extends BaseAction {
   type: string

--- a/src/common/static-types/actions.ts
+++ b/src/common/static-types/actions.ts
@@ -1,4 +1,4 @@
-import { ReduxAPIError } from '../reducers/static-types'
+import { ReduxAPIError } from './api-struct'
 
 export interface BaseAction {
   type: string

--- a/src/common/static-types/api-struct.ts
+++ b/src/common/static-types/api-struct.ts
@@ -1,4 +1,4 @@
-import { StatusCode } from '../common/static-types/status-code'
+import { StatusCode } from './status-code'
 
 export interface ReduxAPIError {
   statusCode: StatusCode | null

--- a/src/components/molecules/Lists/BranchList/index.tsx
+++ b/src/components/molecules/Lists/BranchList/index.tsx
@@ -3,7 +3,7 @@ import List from '@material-ui/core/List'
 import BranchForm from '../../../molecules/Forms/BranchForm'
 import BranchListItem from '../../../atoms/ListItems/BranchListItem'
 import { FirebaseSnapShot } from '../../../../utils/firebase'
-import { ReduxAPIStruct } from '../../../../reducers/static-types'
+import { ReduxAPIStruct } from '../../../../common/static-types/api-struct'
 
 interface Props {
   branches: ReduxAPIStruct<FirebaseSnapShot[]>

--- a/src/components/molecules/Lists/DirectoryList/index.tsx
+++ b/src/components/molecules/Lists/DirectoryList/index.tsx
@@ -7,7 +7,7 @@ import Divider from '@material-ui/core/Divider'
 import DirectoryListItem from '../../../atoms/ListItems/DirectoryListItem'
 import * as styles from './style.css'
 import { FirebaseSnapShot } from '../../../../utils/firebase'
-import { ReduxAPIStruct } from '../../../../reducers/static-types'
+import { ReduxAPIStruct } from '../../../../common/static-types/api-struct'
 
 interface Props {
   directories: ReduxAPIStruct<FirebaseSnapShot[]>

--- a/src/components/organisms/MyPageList/index.tsx
+++ b/src/components/organisms/MyPageList/index.tsx
@@ -3,7 +3,7 @@ import { FirebaseSnapShot } from '../../../utils/firebase'
 import DirectoryForm from '../../molecules/Forms/DirectoryForm'
 import DirectoryList from '../../molecules/Lists/DirectoryList'
 import BranchList from '../../molecules/Lists/BranchList'
-import { ReduxAPIStruct } from '../../../reducers/static-types'
+import { ReduxAPIStruct } from '../../../common/static-types/api-struct'
 import * as styles from './style.css'
 
 interface Props {

--- a/src/components/pages/DirectoryPage/index.tsx
+++ b/src/components/pages/DirectoryPage/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import { RouteComponentProps, Link } from 'react-router-dom'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import { checkDirectoryId } from '../../../actions/directories'
-import { ReduxAPIStruct } from '../../../reducers/static-types'
+import { ReduxAPIStruct } from '../../../common/static-types/api-struct'
 import { FirebaseSnapShot } from '../../../utils/firebase'
 import BranchForm from '../../molecules/Forms/BranchForm'
 

--- a/src/components/pages/EditorPage/index.tsx
+++ b/src/components/pages/EditorPage/index.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps } from 'react-router-dom'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import { checkDirectoryId } from '../../../actions/directories'
 import { checkBranchId } from '../../../actions/branches'
-import { ReduxAPIStruct } from '../../../reducers/static-types'
+import { ReduxAPIStruct } from '../../../common/static-types/api-struct'
 import EditorTemplate from '../../templates/EditorTemplate'
 
 interface MatchParams {

--- a/src/components/pages/MyPage/index.tsx
+++ b/src/components/pages/MyPage/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import { fetchDirectories } from '../../../actions/directories'
-import { ReduxAPIStruct } from '../../../reducers/static-types'
+import { ReduxAPIStruct } from '../../../common/static-types/api-struct'
 import { FirebaseSnapShot } from '../../../utils/firebase'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import MyPageTemplate from '../../templates/MyPageTemplate'

--- a/src/components/templates/MyPageTemplate/index.tsx
+++ b/src/components/templates/MyPageTemplate/index.tsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import { FirebaseSnapShot } from '../../../utils/firebase'
 import Header from '../../molecules/Header'
 import MyPageList from '../../organisms/MyPageList'
-import { ReduxAPIStruct } from '../../../reducers/static-types'
+import { ReduxAPIStruct } from '../../../common/static-types/api-struct'
 import * as styles from './style.css'
 
 interface Props {

--- a/src/reducers/branches.ts
+++ b/src/reducers/branches.ts
@@ -1,5 +1,5 @@
 import { actionTypes } from '../common/constants/action-types'
-import { ReduxAPIStruct, defaultSet } from './static-types'
+import { ReduxAPIStruct, defaultSet } from '../common/static-types/api-struct'
 import { BranchesAction, IsInvalidBranchAction } from '../actions/branches'
 import { FirebaseSnapShot } from '../utils/firebase'
 

--- a/src/reducers/commits.ts
+++ b/src/reducers/commits.ts
@@ -1,5 +1,5 @@
 import { actionTypes } from '../common/constants/action-types'
-import { ReduxAPIStruct, defaultSet } from './static-types'
+import { ReduxAPIStruct, defaultSet } from '../common/static-types/api-struct'
 import { CommitsAction } from '../actions/commits'
 import { FirebaseSnapShot } from '../utils/firebase'
 

--- a/src/reducers/directories.ts
+++ b/src/reducers/directories.ts
@@ -1,5 +1,5 @@
 import { actionTypes } from '../common/constants/action-types'
-import { ReduxAPIStruct, defaultSet } from './static-types'
+import { ReduxAPIStruct, defaultSet } from '../common/static-types/api-struct'
 import {
   DirectoriesAction,
   IsInvalidDirectoryAction,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
static-typesファイルが散らばっていたので、見やすいように `common/static-types`ディレクトリ配下に集めました