### PR TITLE
Refactor editor

### DIFF
--- a/src/components/organisms/MarkdownEditor/index.tsx
+++ b/src/components/organisms/MarkdownEditor/index.tsx
@@ -35,10 +35,6 @@ const MarkdownEditor: React.FC<Props> = ({ currentUser, directoryId, branchId })
   const rawContentState = convertToRaw(contentState)
   const rawContentBlocks = rawContentState.blocks // 複数回使うのでここで定義
 
-  const onChange = (editorState: EditorState) => {
-    setEditorState(editorState)
-  }
-
   useEffect(() => {
     const rawStateSavedOnStorage = localStorage.getItem(branchId)
     if (!rawStateSavedOnStorage) {
@@ -79,18 +75,10 @@ const MarkdownEditor: React.FC<Props> = ({ currentUser, directoryId, branchId })
   ): DraftHandleValue => {
     const newState = RichUtils.handleKeyCommand(editorState, command)
     if (newState) {
-      onChange(newState)
+      setEditorState(newState)
       return 'handled'
     }
     return 'not-handled'
-  }
-
-  const toggleBlockType = (blockStyle: string): void => {
-    onChange(RichUtils.toggleBlockType(editorState, blockStyle))
-  }
-
-  const toggleInlineStyle = (inlineStyle: string): void => {
-    onChange(RichUtils.toggleInlineStyle(editorState, inlineStyle))
   }
 
   // NOTE: Pluginの型は厳密につけられていないのでバグの温床になっていることに留意
@@ -101,7 +89,7 @@ const MarkdownEditor: React.FC<Props> = ({ currentUser, directoryId, branchId })
       {/* HOPE TODO: placeholderをいい感じの文章のランダムにしたい */}
       <Editor
         editorState={editorState}
-        onChange={onChange}
+        onChange={(editorState: EditorState) => setEditorState(editorState)}
         handleKeyCommand={handleKeyCommand}
         plugins={plugins}
         customStyleMap={STYLE_MAP}
@@ -110,8 +98,12 @@ const MarkdownEditor: React.FC<Props> = ({ currentUser, directoryId, branchId })
       <EditorToolBar
         shouldShowToolBar={shouldShowToolBar}
         shouldShowToolBarInline={shouldShowToolBarInline}
-        toggleBlockType={toggleBlockType}
-        toggleInlineStyle={toggleInlineStyle}
+        toggleBlockType={(blockStyle: string) => {
+          setEditorState(RichUtils.toggleBlockType(editorState, blockStyle))
+        }}
+        toggleInlineStyle={(inlineStyle: string) => {
+          setEditorState(RichUtils.toggleInlineStyle(editorState, inlineStyle))
+        }}
       />
       <CommitForm
         currentUser={currentUser}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
onChange, toggleBlockType, toggleInlineStyleという三つの変数を無くしました。
## Motivation
- 他のコンポーネントならリファクタは優先事項ではないが、markdowneditorはelaborateのメイン部分でありただでさえ太りやすいのでなるべくスリムかつ見やすくしたい。
- 少なくともonChangeは変数名に見合わない使われ方をしていた。
