### PR TITLE
Fix ooops bug

### DIFF
--- a/src/components/molecules/Lists/BranchList/index.tsx
+++ b/src/components/molecules/Lists/BranchList/index.tsx
@@ -12,22 +12,14 @@ interface Props {
 }
 
 const BranchList: React.FC<Props> = ({ branches, currentUser, selectedDirectoryId }) => {
-  if (branches.status === 'default' || branches.data === null) {
-    return <div>No directory is selected ...</div>
-  }
+  if (selectedDirectoryId === null) return <div>No directory is selected ...</div>
 
-  if (branches.status === 'fetching' || branches.data === null) {
-    return <div>Loading...</div>
-  }
+  if (branches.status === 'default' || branches.status === 'fetching') return <div>Loading...</div>
 
-  if (branches.status === 'failure') {
-    return <div>Error occured: {branches.error.message}</div>
-  }
+  if (branches.status === 'failure') return <div>Error occured: {branches.error.message}</div>
 
   // MEMO：これが出る場合はバグであることに留意
-  if (selectedDirectoryId === null) {
-    return <div>Ooops! Some unknown error happened</div>
-  }
+  if (branches.data === null) return <div>Ooops! Some unknown error happened</div>
 
   return (
     <Fragment>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
BranchListのコンポーネント表示ロジックを改善
## 詳細
storeはreloadされない限りリセットされないことにより、一度DirectoryがクリックされてfetchBranchesが走りbranches.statusが'success'に切り替わった後react-routerのLinkでmypageに戻ってきた場合storeに `branches.status === 'success'`が格納されたままなので、 `branches.status === 'success'`かつ `selectedDirectoryId === null`という状況が発生しunexpected errorが発生していました。
## 特にレビューしてほしいところ
改善後のロジックでunexpected errorが発生し得ないかレビューしてほしいです。
