### PR TITLE
フォーム入力の際にenterだけを押してもsubmitされないよう修正

### DIFF
--- a/src/common/functions/index.ts
+++ b/src/common/functions/index.ts
@@ -49,3 +49,11 @@ export const convertToText = (rawContentBlocks: RawDraftContentBlock[]) => {
 
   return commitBody
 }
+
+export const handleEnterKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  if (e.key === 'Enter' && e.ctrlKey) {
+    return
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+  }
+}

--- a/src/components/molecules/Forms/BranchForm/index.tsx
+++ b/src/components/molecules/Forms/BranchForm/index.tsx
@@ -84,7 +84,7 @@ const BranchForm: React.FC<Props> = ({
             name="newBranchName"
             placeholder="branch name"
             type="text"
-            onKeyPress={(e: any) => {
+            onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                 return
               } else if (e.key === 'Enter') {

--- a/src/components/molecules/Forms/BranchForm/index.tsx
+++ b/src/components/molecules/Forms/BranchForm/index.tsx
@@ -84,6 +84,13 @@ const BranchForm: React.FC<Props> = ({
             name="newBranchName"
             placeholder="branch name"
             type="text"
+            onKeyPress={(e: any) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                return
+              } else if (e.key === 'Enter') {
+                e.preventDefault()
+              }
+            }}
           />
           <ErrorMessage component="div" name="newBranchName" className={errorMessage} />
           <div className={`${title} ${baseBranch}`}>Base branch</div>

--- a/src/components/molecules/Forms/BranchForm/index.tsx
+++ b/src/components/molecules/Forms/BranchForm/index.tsx
@@ -7,6 +7,7 @@ import { FirebaseSnapShot } from '../../../../utils/firebase'
 import { ReduxAPIStruct } from '../../../../common/static-types/api-struct'
 import { BranchDocumentData } from '../../../../common/static-types/document-data'
 import * as styles from './style.css'
+import { handleEnterKey } from '../../../../common/functions'
 const {
   branchFormWrapper,
   whiteBase,
@@ -84,12 +85,8 @@ const BranchForm: React.FC<Props> = ({
             name="newBranchName"
             placeholder="branch name"
             type="text"
-            onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                return
-              } else if (e.key === 'Enter') {
-                e.preventDefault()
-              }
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              handleEnterKey(e)
             }}
           />
           <ErrorMessage component="div" name="newBranchName" className={errorMessage} />

--- a/src/components/molecules/Forms/CommitForm/index.tsx
+++ b/src/components/molecules/Forms/CommitForm/index.tsx
@@ -68,7 +68,19 @@ const CommitForm: React.FC<Props & DispatchProps> = ({
       }}
       render={() => (
         <Form>
-          <Field className={commitName} name="commitName" placeholder="commit name" type="text" />
+          <Field
+            className={commitName}
+            name="commitName"
+            placeholder="commit name"
+            type="text"
+            onKeyPress={(e: any) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                return
+              } else if (e.key === 'Enter') {
+                e.preventDefault()
+              }
+            }}
+          />
           <ErrorMessage component="div" name="commitName" className={errorMessage} />
           <button type="submit" className={whiteBase}>
             Submit

--- a/src/components/molecules/Forms/CommitForm/index.tsx
+++ b/src/components/molecules/Forms/CommitForm/index.tsx
@@ -5,6 +5,7 @@ import { RawDraftContentBlock } from 'draft-js'
 import Typography from '@material-ui/core/Typography'
 import { createCommit } from '../../../../actions/commits'
 import * as styles from './style.css'
+import { handleEnterKey } from '../../../../common/functions'
 const { commitFormWrapper, title, whiteBase, commitName, errorMessage } = styles
 
 export interface Values {
@@ -74,11 +75,7 @@ const CommitForm: React.FC<Props & DispatchProps> = ({
             placeholder="commit name"
             type="text"
             onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                return
-              } else if (e.key === 'Enter') {
-                e.preventDefault()
-              }
+              handleEnterKey(e)
             }}
           />
           <ErrorMessage component="div" name="commitName" className={errorMessage} />

--- a/src/components/molecules/Forms/CommitForm/index.tsx
+++ b/src/components/molecules/Forms/CommitForm/index.tsx
@@ -73,7 +73,7 @@ const CommitForm: React.FC<Props & DispatchProps> = ({
             name="commitName"
             placeholder="commit name"
             type="text"
-            onKeyPress={(e: any) => {
+            onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                 return
               } else if (e.key === 'Enter') {

--- a/src/components/molecules/Forms/DirectoryForm/index.tsx
+++ b/src/components/molecules/Forms/DirectoryForm/index.tsx
@@ -49,6 +49,13 @@ const DirectoryForm: React.FC<Props> = ({ currentUser, createDirectory }) => (
             name="directoryName"
             placeholder="directory name"
             type="text"
+            onKeyPress={(e: any) => {
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                return
+              } else if (e.key === 'Enter') {
+                e.preventDefault()
+              }
+            }}
           />
           <ErrorMessage component="div" name="directoryName" className={errorMessage} />
           <button type="submit" className={whiteBase}>

--- a/src/components/molecules/Forms/DirectoryForm/index.tsx
+++ b/src/components/molecules/Forms/DirectoryForm/index.tsx
@@ -49,7 +49,7 @@ const DirectoryForm: React.FC<Props> = ({ currentUser, createDirectory }) => (
             name="directoryName"
             placeholder="directory name"
             type="text"
-            onKeyPress={(e: any) => {
+            onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
                 return
               } else if (e.key === 'Enter') {

--- a/src/components/molecules/Forms/DirectoryForm/index.tsx
+++ b/src/components/molecules/Forms/DirectoryForm/index.tsx
@@ -4,6 +4,7 @@ import { Formik, Field, Form, FormikActions, ErrorMessage } from 'formik'
 import Typography from '@material-ui/core/Typography'
 import { createDirectory } from '../../../../actions/directories'
 import * as styles from './style.css'
+import { handleEnterKey } from '../../../../common/functions'
 const { directoryFormWrapper, title, whiteBase, directoryName, errorMessage } = styles
 
 interface Props {
@@ -49,12 +50,8 @@ const DirectoryForm: React.FC<Props> = ({ currentUser, createDirectory }) => (
             name="directoryName"
             placeholder="directory name"
             type="text"
-            onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                return
-              } else if (e.key === 'Enter') {
-                e.preventDefault()
-              }
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+              handleEnterKey(e)
             }}
           />
           <ErrorMessage component="div" name="directoryName" className={errorMessage} />


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
fix https://github.com/bokusunny/Elaborate/issues/296
フォーム入力のUX改善
## 詳細
現状、enterキーのみで入力しているフォームがsubmitされてしまい、間違って送信してしまうことがある。
~Macは「cmd + enter」、Winは「ctrl + enter」~「ctrl + enter」でフォームがsubmitされるように修正。

## 特にレビューしてほしいところ
enterキーの判断している箇所はメソッド化した方がいい？

## 関連Issue
https://github.com/bokusunny/Elaborate/issues/296
## TodoList

## その他
chromeを使っているとcmd + enterが動かないのでsafariで検証済み